### PR TITLE
Honor configured `graceful_stop` in `Service::Controller#stop`

### DIFF
--- a/lib/async/service/controller.rb
+++ b/lib/async/service/controller.rb
@@ -91,7 +91,7 @@ module Async
 			end
 			
 			# Stop all named services.
-			def stop(graceful = true)
+			def stop(graceful = @graceful_stop)
 				@services.each do |service|
 					begin
 						service.stop

--- a/test/async/service/controller.rb
+++ b/test/async/service/controller.rb
@@ -96,6 +96,43 @@ describe Async::Service::Controller do
 			# Should not raise exception
 			controller.stop
 		end
+		
+		# Minimal container stub: needs a real #stop so sus's mock-super chain has a method to call into.
+		let(:container_stub_class) do
+			Class.new do
+				def stop(graceful = true); end
+			end
+		end
+		
+		it "forwards the configured graceful_stop value to the container when called with no arguments" do
+			controller = subject.new([], graceful_stop: 27.5)
+			container = container_stub_class.new
+			controller.instance_variable_set(:@container, container)
+			
+			expect(container).to receive(:stop).with(27.5)
+			
+			controller.stop
+		end
+		
+		it "forwards the default graceful_stop value (true) when no value is configured" do
+			controller = subject.new([])
+			container = container_stub_class.new
+			controller.instance_variable_set(:@container, container)
+			
+			expect(container).to receive(:stop).with(true)
+			
+			controller.stop
+		end
+		
+		it "forwards an explicit false argument unchanged (force-kill path)" do
+			controller = subject.new([], graceful_stop: 27.5)
+			container = container_stub_class.new
+			controller.instance_variable_set(:@container, container)
+			
+			expect(container).to receive(:stop).with(false)
+			
+			controller.stop(false)
+		end
 	end
 end
 


### PR DESCRIPTION
## Summary

`Async::Service::Controller#stop` declares `def stop(graceful = true)`, which shadows the parent's `Async::Container::Controller#stop(graceful = @graceful_stop)`. When the controller is asked to stop on `SIGINT`/`SIGTERM`, `Async::Container::Controller#run` invokes `self.stop` with no arguments (in `rescue Interrupt`); the subclass override binds `graceful = true` locally and bare `super` forwards that literal `true` positionally, displacing the parent's `@graceful_stop` default.

Net effect: the value passed to `Async::Service::Controller.new(..., graceful_stop: X)` is stored on `@graceful_stop` but never consulted on the SIGTERM shutdown path. Downstream, `Async::Container::Group#stop` always receives `true`, which expands to the hardcoded `DEFAULT_GRACEFUL_TIMEOUT = 10.0`. This silently nullifies, for example, `falcon serve --graceful-stop 30` (and equivalent wiring on `falcon host`), capping the effective drain window at 10 seconds.

The fix is one line — restore the parent's contract:

```diff
-def stop(graceful = true)
+def stop(graceful = @graceful_stop)
```

Bare `super` still forwards positionally; the parent's `initialize(graceful_stop: true)` default means callers that never pass `graceful_stop:` get identical behavior to today. Explicit `controller.stop(false)` from `rescue Terminate` and `ensure` (the force-kill paths in the parent's `#run`) is also unchanged. The only behavior change is the intended one: a passed-in value is now honored.

## Tests

The existing tests at `test/async/service/controller.rb:66-99` cover `stop(true)`, `stop(false)`, and `stop` (no args), but never assert what value the controller forwards to its container. This PR adds three tests that pin the contract on `@container.stop`:

- `graceful_stop: 27.5` then `controller.stop` → expects `@container.stop(27.5)`. **Fails on `main`** (`expect [true] to be == [27.5]`).
- no `graceful_stop:` then `controller.stop` → expects `@container.stop(true)` (default unchanged).
- `graceful_stop: 27.5` then `controller.stop(false)` → expects `@container.stop(false)` (force-kill unchanged).

All three pass with the fix; full gem suite (113 examples) stays green.

## Related

- Open issue #3 (\"Expose graceful stop timeout\") is adjacent — it asks for the timeout to be configurable in `Async::Container::Group`, without identifying that `Service::Controller` already accepts `graceful_stop:` and silently drops it on the SIGTERM path.
- The same shadowing pattern (`def stop(graceful = true)` on a subclass that has a `@graceful_stop`-aware parent) also appears in `lib/async/service/generic.rb:60` and in the architecture-guide example at `guides/service-architecture/readme.md:166`. Out of scope for this minimal PR but worth a follow-up if the maintainer agrees.

## Test plan

- [x] New tests fail on unmodified upstream and pass with the one-line fix.
- [x] Existing controller tests unaffected.
- [x] Full async-service test suite (`bundle exec sus`) passes: 113/113.
- [x] `bundle exec rubocop lib/async/service/controller.rb test/async/service/controller.rb` clean.

cc @ioquatix