### PR TITLE
Set managed service container name. Fixes #7.

### DIFF
--- a/lib/async/service/managed/environment.rb
+++ b/lib/async/service/managed/environment.rb
@@ -36,6 +36,7 @@ module Async
 				# @returns [Hash] The options for the container.
 				def container_options
 					{
+						name: self.name,
 						restart: true,
 						count: self.count,
 						startup_timeout: self.startup_timeout,

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Managed services now pass their service name through container options by default, restoring process titles for forked and hybrid containers.
+
 ## v0.23.0
 
   - `Async::Service::Generic.wrap` now checks for a `make_service(environment)` method on the evaluator before falling back to `service_class`. This allows environments to compose child environments and return a fully-constructed service without introducing a dedicated service class.

--- a/test/async/service/managed/environment.rb
+++ b/test/async/service/managed/environment.rb
@@ -23,6 +23,7 @@ describe Async::Service::Managed::Environment do
 	it "provides default container options" do
 		options = evaluator.container_options
 		
+		expect(options[:name]).to be == "test-managed"
 		expect(options[:restart]).to be == true
 		expect(options[:count]).to be == 3
 		expect(options[:health_check_timeout]).to be == 10

--- a/test/async/service/managed/service.rb
+++ b/test/async/service/managed/service.rb
@@ -57,9 +57,38 @@ describe Async::Service::Managed::Service do
 		
 		# Verify the container options were passed correctly
 		expect(options_captured).not.to be_nil
+		expect(options_captured[:name]).to be == "test-container"
 		expect(options_captured[:count]).to be == 2
 		expect(options_captured[:health_check_timeout]).to be == 5
 		expect(options_captured[:restart]).to be == true
+	end
+	
+	it "allows container options to override the process name" do
+		configuration = Async::Service::Configuration.build do
+			service "test-container" do
+				service_class Async::Service::Managed::Service
+				include Async::Service::Managed::Environment
+				
+				container_options do
+					super().merge(name: "custom-process-name")
+				end
+			end
+		end
+		
+		service = configuration.services.first
+		container = Async::Container.new
+		options_captured = nil
+		
+		mock(container) do |mock|
+			mock.replace(:run) do |**options, &block|
+				options_captured = options
+				nil
+			end
+		end
+		
+		service.setup(container)
+		
+		expect(options_captured[:name]).to be == "custom-process-name"
 	end
 	
 	with "integration test" do


### PR DESCRIPTION
## Summary
- include the service name in managed container options by default
- verify managed services pass the name through to container.run while preserving explicit name overrides
- add an Unreleased release note

## Tests
- bundle exec sus test/async/service/managed/environment.rb
- bundle exec sus test/async/service/managed/service.rb

Fixes #7.